### PR TITLE
[ui] fix js compile

### DIFF
--- a/actdocs/templates/ui
+++ b/actdocs/templates/ui
@@ -197,11 +197,9 @@
 <!-- Place this render call where appropriate -->
 <script type="text/javascript">
   (function() {
-    var po = document.createElement('script'); po.type = 'text/javascript'; po.a
-sync = true;
+    var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
     po.src = 'https://apis.google.com/js/plusone.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefor
-e(po, s);
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
   })();
 </script>
 


### PR DESCRIPTION
Two JS directives are/were supposed to be unbroken, but somehow were
broken into multiple lines; this breaks/broke JS features on the LPW2015
site, such as favouriting.
